### PR TITLE
Fix LIST file name in case of STORAGE_TYPE == STORAGE_SD

### DIFF
--- a/FtpServer.cpp
+++ b/FtpServer.cpp
@@ -1408,7 +1408,10 @@ bool FtpServer::doList()
 //		data.print( F(",\t") );
 //		data.println( fileDir.name() );
 
-		generateFileLine(&data, false, fileDir.name(), long( fileDir.size()), "Jan 01 00:00", this->user);
+		String fn = fileDir.name();
+		fn.remove(0, fn.lastIndexOf("/")+1);
+
+		generateFileLine(&data, fileDir.isDirectory(), fn.c_str(), long( fileDir.size()), "Jan 01 00:00", this->user);
 
 		nbMatch ++;
 		return true;


### PR DESCRIPTION
This PR fixes #19 

The `fileDir.name()` method returns the full path. It is necessary to extract only its file name in order to use it as a response message to LIST command.  For `STORAGE_SD`, this process was not implemented. This PR introduce this process to `STORAGE_SD`.