### PR TITLE
Add a universal command hook (FtpResponse facade) + custom cooperative transfers

### DIFF
--- a/FtpServer.cpp
+++ b/FtpServer.cpp
@@ -1393,9 +1393,7 @@ bool FtpServer::dataConnected()
 {
   if( data.connected())
     return true;
-  data.stop();
-  client.println(F("426 Data connection closed. Transfer aborted") );
-  transferStage = FTP_Close;
+  abortTransfer(F("426 Data connection closed. Transfer aborted"));
   return false;
 }
  
@@ -1496,8 +1494,8 @@ bool FtpServer::doRetrieve()
   // Handle resume if REST was used
   if (restartPos > 0) {
       if (!file.seek(restartPos)) {
-          client.println(F("450 Cannot seek to restart position."));
-          closeTransfer();
+          DEBUG_PRINTLN(F("ERROR: cannot seek to restart position"));
+          abortTransfer(F("450 Cannot seek to restart position."));
           return false;
       }
       bytesTransfered = restartPos; // Adjust the transferred bytes
@@ -1534,7 +1532,7 @@ bool FtpServer::doRetrieve()
 
     if (written <= 0) {
       DEBUG_PRINTLN(F("ERROR: data.write returned <= 0"));
-      closeTransfer();
+      abortTransfer();
       return false;
     }
 
@@ -1548,6 +1546,14 @@ bool FtpServer::doRetrieve()
       DEBUG_PRINT(F("MORE WRITTEN -> "));
       DEBUG_PRINTLN(more);
       if (more > 0) written += more;
+    }
+
+    // file.read() advanced the cursor by the full nb, so whatever went unsent must be re-read
+    // next round — otherwise those bytes vanish from the middle of the stream, silently.
+    if (written < nb && !file.seek(bytesTransfered + written)) {
+      DEBUG_PRINTLN(F("ERROR: cannot rewind after a short write"));
+      abortTransfer();   // the unsent bytes are unrecoverable — this is not a completed transfer
+      return false;
     }
 
     // Try to flush the socket where available (ESP-specific)
@@ -1566,9 +1572,10 @@ bool FtpServer::doRetrieve()
     DEBUG_PRINT(F("DATA CONNECTED AFTER WRITE -> "));
     DEBUG_PRINTLN(data.connected() ? 1 : 0);
 
+    // Reachable only with bytes still to send, so the peer left mid-file: the transfer failed.
     if (!data.connected()) {
       DEBUG_PRINTLN(F("Data socket closed by peer after write"));
-      closeTransfer();
+      abortTransfer();
       return false;
     }
 
@@ -1607,8 +1614,9 @@ bool FtpServer::doStore()
         DEBUG_PRINT(F("No data received after "));
         DEBUG_PRINT(waited);
         DEBUG_PRINTLN(F(" ms"));
-        // Decide to close transfer to avoid infinite loop and client timeout
-        closeTransfer();
+        // A peer that finished a STOR closes the data connection; one still connected and
+        // silent has stalled, so answering 226 would call an unfinished upload complete.
+        abortTransfer();
         return false;
       }
       // else continue and read available data below
@@ -1662,9 +1670,8 @@ bool FtpServer::doStore()
   if( nb < 0 || rc == nb  ) {
     return true;
   }
-  client.println(F("552 Probably insufficient storage space") );
-  file.close();
-  data.stop();
+
+  abortTransfer(F("552 Probably insufficient storage space"));
   return false;
 }
 
@@ -2195,15 +2202,15 @@ void FtpServer::closeTransfer()
 
   data.stop();
 
+  // Fires on every completed transfer, including an empty or sub-millisecond one.
+  if (FtpServer::_transferCallback) {
+	  FtpServer::_transferCallback(FTP_TRANSFER_STOP, getFileName(&file).c_str(), bytesTransfered);
+  }
+
   if( deltaT > 0 && bytesTransfered > 0 )
   {
 	  DEBUG_PRINT( F(" Transfer completed in ") ); DEBUG_PRINT( deltaT ); DEBUG_PRINTLN( F(" ms, ") );
 	  DEBUG_PRINT( bytesTransfered / deltaT ); DEBUG_PRINTLN( F(" kbytes/s") );
-
-	  if (FtpServer::_transferCallback) {
-		  FtpServer::_transferCallback(FTP_TRANSFER_STOP, getFileName(&file).c_str(), bytesTransfered);
-	  }
-
 
     client.println(F("226-File successfully transferred") );
     client.print( F("226 ") ); client.print( deltaT ); client.print( F(" ms, ") );
@@ -2213,11 +2220,14 @@ void FtpServer::closeTransfer()
     client.println(F("226 File successfully transferred") );
 }
 
-void FtpServer::abortTransfer()
+void FtpServer::abortTransfer(const __FlashStringHelper* reply)
 {
   if( transferStage != FTP_Close )
   {
-	  if (FtpServer::_transferCallback) {
+	  // A listing has no file and no byte count of its own: reporting one would hand the
+	  // application the name and total of whatever transfer ran before it.
+	  const bool sending_file = ( transferStage == FTP_Retrieve || transferStage == FTP_Store );
+	  if (sending_file && FtpServer::_transferCallback) {
 		  FtpServer::_transferCallback(FTP_TRANSFER_ERROR, getFileName(&file).c_str(), bytesTransfered);
 	  }
 
@@ -2225,7 +2235,7 @@ void FtpServer::abortTransfer()
 #if STORAGE_TYPE != STORAGE_SPIFFS && STORAGE_TYPE != STORAGE_LITTLEFS && STORAGE_TYPE != STORAGE_SEEED_SD
     dir.close();
 #endif
-    client.println(F("426 Transfer aborted") );
+    client.println( reply ? reply : F("426 Transfer aborted") );
     DEBUG_PRINTLN( F(" Transfer aborted!") );
 
     transferStage = FTP_Close;

--- a/FtpServer.cpp
+++ b/FtpServer.cpp
@@ -448,13 +448,15 @@ uint8_t FtpServer::handleFTP() {
 
 		// Out of the chain above, whose tail this was: a running transfer always took its own
 		// branch, so the deadline was never reached — and doRetrieve() now waits a stalled peer
-		// out instead of aborting, leaving nothing else to end it. RETR refreshes this deadline
-		// as it sends; the other types never do, so bounding them would kill them mid-progress.
-		const bool in_retrieve = (transferStage == FTP_Retrieve);
-		if (cmdStage > FTP_Client && (transferStage == FTP_Close || in_retrieve)
+		// out instead of aborting, leaving nothing else to end it. RETR and the listings both
+		// refresh this deadline as they send, so it ends only what stopped sending; STOR does
+		// not refresh it and stays out of scope rather than die mid-progress.
+		const bool in_transfer = (transferStage == FTP_Retrieve || transferStage == FTP_List
+				|| transferStage == FTP_Nlst || transferStage == FTP_Mlsd);
+		if (cmdStage > FTP_Client && (transferStage == FTP_Close || in_transfer)
 				&& !((int32_t) (millisEndConnection - millis()) > 0)) {
 			DEBUG_PRINTLN(F("Timeout"));
-			if (in_retrieve) {
+			if (in_transfer) {
 				// NOT closeTransfer(): that answers 226. abortTransfer() replies 426 and fires
 				// FTP_TRANSFER_ERROR, which releases what the app took.
 				abortTransfer();

--- a/FtpServer.cpp
+++ b/FtpServer.cpp
@@ -880,6 +880,10 @@ bool FtpServer::processCommand()
     	DEBUG_PRINTLN(F("Dir opened!!"));
 
         nbMatch = 0;
+        // Reset here rather than where a listing ends: a client that drops the data
+        // connection mid-entry ends one through neither closeTransfer() nor abortTransfer(),
+        // and the entry left pending would open the next listing.
+        listLineLen = listLineSent = 0;
         if( CommandIs( "LIST" ))
           transferStage = FTP_List;
         else if( CommandIs( "NLST" ))
@@ -1536,7 +1540,7 @@ bool FtpServer::doRetrieve()
   {
     // write() may not send everything in one call on some clients; capture return
     int32_t written = 0;
-    written = data.write( buf, nb );
+    written = writeData( (const uint8_t*) buf, nb );
 
     DEBUG_PRINT(F("NB --> "));
     DEBUG_PRINTLN(nb);
@@ -1549,7 +1553,7 @@ bool FtpServer::doRetrieve()
       DEBUG_PRINT(F("Partial write, attempting remainder -> "));
       DEBUG_PRINTLN(remaining);
       const uint8_t* p = (const uint8_t*)buf + written;
-      int32_t more = data.write(p, remaining);
+      int32_t more = writeData(p, remaining);
       DEBUG_PRINT(F("MORE WRITTEN -> "));
       DEBUG_PRINTLN(more);
       if (more > 0) written += more;
@@ -1587,12 +1591,6 @@ bool FtpServer::doRetrieve()
     }
 
     bytesTransfered += written;
-
-    // Progress pushes the idle deadline out; a round that sent nothing deliberately does not —
-    // a zero write is often a transient shut window, and that deadline ends a peer really gone.
-    if (written > 0) {
-      millisEndConnection = millis() + 1000L * FTP_TIME_OUT;
-    }
 
 	  // Invoke callback on real progress: a stalled round must not look like a moving one to a watching app.
 	  if (written > 0 && FtpServer::_transferCallback) {
@@ -1689,59 +1687,17 @@ bool FtpServer::doStore()
   return false;
 }
 
-void generateFileLine(FTP_CLIENT_NETWORK_CLASS* data, bool isDirectory, const char* fn, long fz, const char* time, const char* user, bool writeFilename = true) {
-	if( isDirectory ) {
-		//			  data->print( F("+/,\t") );
-		//			  DEBUG_PRINT(F("+/,\t"));
-
-		data->print( F("drwxrwsr-x\t2\t"));
-		data->print( user );
-		data->print( F("\t") );
-		data->print( long( 4096 ) );
-		data->print( F("\t") );
-
-		DEBUG_PRINT( F("drwxrwsr-x\t2\t") );
-		DEBUG_PRINT( user );
-		DEBUG_PRINT( F("\t") );
-
-		DEBUG_PRINT( long( 4096 ) );
-		DEBUG_PRINT( F("\t") );
-
-		data->print(time);
-		DEBUG_PRINT(time);
-
-		data->print( F("\t") );
-		if (writeFilename) data->println( fn );
-
-		DEBUG_PRINT( F("\t") );
-		if (writeFilename) DEBUG_PRINTLN( fn );
-
-	} else {
-//			data.print( F("+r,s") );
-//			DEBUG_PRINT(F("+r,s"));
-
-		data->print( F("-rw-rw-r--\t1\t") );
-		data->print( user );
-		data->print( F("\t") );
-		data->print( fz );
-		data->print( F("\t") );
-
-		DEBUG_PRINT( F("-rw-rw-r--\t1\t") );
-		DEBUG_PRINT( user );
-		DEBUG_PRINT( F("\t") );
-		DEBUG_PRINT( fz );
-		DEBUG_PRINT( F("\t") );
-
-		data->print(time);
-		DEBUG_PRINT(time);
-
-		data->print( F("\t") );
-		if (writeFilename) data->println( fn );
-
-		DEBUG_PRINT( F("\t") );
-		if (writeFilename) DEBUG_PRINTLN( fn );
-	}
-
+// Renders one LIST entry into `out` and returns the length the whole line needs, which may
+// exceed `outSize` — the caller decides what a line too long for its buffer becomes, and it
+// cannot decide that from a length already clamped to the buffer. Building the line before
+// any of it is sent is what lets a caller resume a partial write: nine separate print()
+// calls could not, and each of them burns the socket's whole write budget again when the
+// peer's window is shut.
+size_t generateFileLine(char* out, size_t outSize, bool isDirectory, const char* fn, long fz, const char* time, const char* user) {
+	const int n = snprintf(out, outSize, "%s\t%s\t%ld\t%s\t%s\r\n",
+			isDirectory ? "drwxrwsr-x\t2" : "-rw-rw-r--\t1",
+			user, isDirectory ? 4096L : fz, time, fn);
+	return n < 0 ? 0 : (size_t) n;
 }
 
 #if defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
@@ -1793,10 +1749,68 @@ String makeDateTimeStrList(time_t ft, bool dateContracted = false)
 }
 
 // https://files.stairways.com/other/ftp-list-specs-info.txt
-void generateFileLine(FTP_CLIENT_NETWORK_CLASS* data, bool isDirectory, const char* fn, long fz, time_t time, const char* user, bool writeFilename = true) {
-	generateFileLine(data, isDirectory, fn, fz, makeDateTimeStrList(time).c_str(), user, writeFilename);
+size_t generateFileLine(char* out, size_t outSize, bool isDirectory, const char* fn, long fz, time_t time, const char* user) {
+	return generateFileLine(out, outSize, isDirectory, fn, fz, makeDateTimeStrList(time).c_str(), user);
 }
 #endif
+
+// Renders one listing entry into listLine. Callers hand over the values their storage
+// backend exposes; the wire format is the backend-independent part.
+// Takes what snprintf() reported and returns the length to send. A line longer than the buffer
+// is truncated by snprintf without its CRLF, and a listing entry with no line ending merges into
+// the next one at the client, so the ending is restored over the last two bytes.
+uint16_t FtpServer::finishListLine(int rendered)
+{
+  listLineSent = 0;
+  if( rendered <= 0 ) return 0;
+  if( (size_t) rendered < sizeof( listLine )) return (uint16_t) rendered;
+  listLine[ sizeof( listLine ) - 3 ] = '\r';
+  listLine[ sizeof( listLine ) - 2 ] = '\n';
+  listLine[ sizeof( listLine ) - 1 ] = '\0';
+  return (uint16_t) ( sizeof( listLine ) - 1 );
+}
+
+// Renders one listing entry into listLine. Callers hand over the values their storage backend
+// exposes; the wire format is the backend-independent part.
+void FtpServer::buildListLine(bool isNlst, bool isDirectory, const char* fn, long fz, const char* time)
+{
+  const int n = isNlst ? snprintf( listLine, sizeof( listLine ), "%s\r\n", fn )
+                       : (int) generateFileLine( listLine, sizeof( listLine ), isDirectory, fn, fz, time, this->user );
+  listLineLen = finishListLine( n );
+  DEBUG_PRINT( listLine );
+}
+
+void FtpServer::buildListLine(bool isNlst, bool isDirectory, const char* fn, long fz, time_t time)
+{
+  buildListLine( isNlst, isDirectory, fn, fz, makeDateTimeStrList( time ).c_str());
+}
+
+void FtpServer::buildMlsdLine(bool isDirectory, const char* dtStr, long fz, const char* fn)
+{
+  const int n = snprintf( listLine, sizeof( listLine ), "Type=%s;Modify=%s;Size=%ld; %s\r\n",
+                          isDirectory ? "dir" : "file", dtStr, fz, fn );
+  listLineLen = finishListLine( n );
+  DEBUG_PRINT( listLine );
+}
+
+size_t FtpServer::writeData(const uint8_t* p, size_t len)
+{
+  const size_t n = data.write( p, len );
+  if( n > 0 ) millisEndConnection = millis() + 1000L * FTP_TIME_OUT;
+  return n;
+}
+
+bool FtpServer::sendListLine()
+{
+  if( listLineLen == 0 ) return true;
+  listLineSent += (uint16_t) writeData((const uint8_t*) listLine + listLineSent,
+                                       listLineLen - listLineSent );
+  if( listLineSent < listLineLen ) return false;
+  listLineLen = 0;
+  listLineSent = 0;
+  nbMatch ++;
+  return true;
+}
 
 bool FtpServer::doList()
 {
@@ -1807,6 +1821,10 @@ bool FtpServer::doList()
 #endif
     return false;
   }
+
+  // An entry already rendered owns this round: its directory slot is gone, so the
+  // remainder has to go out before the cursor may move again.
+  if( listLineLen > 0 && ! sendListLine()) return true;
 
   // Determine if current transfer is NLST (name list) so we only send filenames
   bool isNlst = (transferStage == FTP_Nlst);
@@ -1824,12 +1842,7 @@ bool FtpServer::doList()
 	  long fz = long( dir.fileSize());
 	  if (fn[0]=='/') { fn.remove(0, fn.lastIndexOf("/")+1); }
 	  time_t time = dir.fileTime();
-	  if (isNlst) {
-	    data.println(fn.c_str());
-	    DEBUG_PRINTLN(fn);
-	  } else {
-	    generateFileLine(&data, false, fn.c_str(), fz, time, this->user);
-	  }
+	  buildListLine( isNlst, false, fn.c_str(), fz, time );
 #else
 	  long fz = long( fileDir.size());
 	  const char* fnC = fileDir.name();
@@ -1841,16 +1854,11 @@ bool FtpServer::doList()
 	  }
 
 	  time_t time = fileDir.getLastWrite();
-	  if (isNlst) {
-	    data.println(fn);
-	    DEBUG_PRINTLN(fn);
-	  } else {
-	    generateFileLine(&data, false, fn, fz, time, this->user);
-	  }
+	  buildListLine( isNlst, false, fn, fz, time );
 
 #endif
 
-    nbMatch ++;
+    sendListLine();
     return true;
   }
 #elif STORAGE_TYPE == STORAGE_LITTLEFS || STORAGE_TYPE == STORAGE_SEEED_SD || STORAGE_TYPE == STORAGE_FFAT
@@ -1897,21 +1905,14 @@ bool FtpServer::doList()
 //		DEBUG_PRINT( F("\t") );
 //		DEBUG_PRINTLN( fileDir.name() );
 	#endif
-	if (isNlst) {
-		data.println(fn);
-		DEBUG_PRINTLN(fn);
-	} else {
-		#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
-			time_t time = dir.fileTime();
-			generateFileLine(&data, dir.isDirectory(), fn, fz, time, this->user);
-		#elif defined(ESP32)
-			time_t time = fileDir.getLastWrite();
-			generateFileLine(&data, fileDir.isDirectory(), fn, fz, time, this->user);
-		#else
-				generateFileLine(&data, fileDir.isDirectory(), fn, fz, "Jan 01 00:00", this->user);
-		#endif
-	}
-    nbMatch ++;
+	#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
+		buildListLine( isNlst, dir.isDirectory(), fn, fz, dir.fileTime());
+	#elif defined(ESP32)
+		buildListLine( isNlst, fileDir.isDirectory(), fn, fz, fileDir.getLastWrite());
+	#else
+		buildListLine( isNlst, fileDir.isDirectory(), fn, fz, "Jan 01 00:00" );
+	#endif
+    sendListLine();
     return true;
   }
 #elif STORAGE_TYPE == STORAGE_SD || STORAGE_TYPE == STORAGE_SD_MMC
@@ -1924,22 +1925,12 @@ bool FtpServer::doList()
 
 #if STORAGE_TYPE == STORAGE_SD_MMC
 		time_t time = fileDir.getLastWrite();
-		if (isNlst) {
-			data.println(fn.c_str());
-			DEBUG_PRINTLN(fn);
-		} else {
-			generateFileLine(&data, fileDir.isDirectory(), fn.c_str(), long( fileDir.size()), time, this->user);
-		}
+		buildListLine( isNlst, fileDir.isDirectory(), fn.c_str(), long( fileDir.size()), time );
 #else
-		if (isNlst) {
-			data.println(fn.c_str());
-			DEBUG_PRINTLN(fn);
-		} else {
-			generateFileLine(&data, fileDir.isDirectory(), fn.c_str(), long( fileDir.size()), "Jan 01 00:00", this->user);
-		}
+		buildListLine( isNlst, fileDir.isDirectory(), fn.c_str(), long( fileDir.size()), "Jan 01 00:00" );
 #endif
 
-		nbMatch ++;
+		sendListLine();
 		return true;
   }
 
@@ -1950,31 +1941,19 @@ bool FtpServer::doList()
 		String fn = dir.fileName();
 		if (fn[0]=='/') { fn.remove(0, fn.lastIndexOf("/")+1); }
 
-	if (isNlst) {
-		data.println(fn.c_str());
-		DEBUG_PRINTLN(fn);
-	} else {
-		generateFileLine(&data, dir.isDir(), fn.c_str(), long( dir.fileSize()), "Jan 01 00:00", this->user);
-	}
+	buildListLine( isNlst, dir.isDir(), fn.c_str(), long( dir.fileSize()), "Jan 01 00:00" );
 
-    nbMatch ++;
+    sendListLine();
     return true;
   }
 #else
   if( file.openNext( &dir, FTP_FILE_READ_ONLY ))
   {
-	// For storages using file.printName, only send name in NLST mode
-	if (isNlst) {
-		file.printName(&data);
-		data.println();
-	} else {
-		generateFileLine(&data, file.isDir(), "", long( fileSize( file )), "Jan 01 00:00", this->user, false);
-
-		file.printName( & data );
-		data.println();
-	}
+	char nameBuf[ FTP_CWD_SIZE ];
+	file.getName( nameBuf, sizeof( nameBuf ));
+	buildListLine( isNlst, file.isDir(), nameBuf, long( fileSize( file )), "Jan 01 00:00" );
     file.close();
-    nbMatch ++;
+    sendListLine();
     return true;
   }
 #endif
@@ -1999,6 +1978,10 @@ bool FtpServer::doMlsd()
   	DEBUG_PRINTLN(F("Not connected!!"));
     return false;
   }
+  // An entry already rendered owns this round: its directory slot is gone, so the
+  // remainder has to go out before the cursor may move again.
+  if( listLineLen > 0 && ! sendListLine()) return true;
+
   DEBUG_PRINTLN(F("Connected!!"));
 
 #if STORAGE_TYPE == STORAGE_SPIFFS
@@ -2038,21 +2021,8 @@ bool FtpServer::doMlsd()
 		long fz = fileDir.size();
 	#endif
 
-		data.print( F("Type=") );
-
-		data.print( F("file") );
-		data.print( F(";Modify=") ); data.print(dtStr);// data.print( makeDateTimeStr( dtStr, time, time) );
-		data.print( F(";Size=") ); data.print( fz );
-		data.print( F("; ") ); data.println( fn );
-
-		DEBUG_PRINT( F("Type=") );
-		DEBUG_PRINT( F("file") );
-
-		DEBUG_PRINT( F(";Modify=") ); DEBUG_PRINT(dtStr); //DEBUG_PRINT( makeDateTimeStr( dtStr, time, time) );
-		DEBUG_PRINT( F(";Size=") ); DEBUG_PRINT( fz );
-		DEBUG_PRINT( F("; ") ); DEBUG_PRINTLN( fn );
-
-		nbMatch ++;
+		buildMlsdLine( false, dtStr, fz, fn.c_str());
+		sendListLine();
 		return true;
 	  }
 #elif STORAGE_TYPE == STORAGE_LITTLEFS || STORAGE_TYPE == STORAGE_SEEED_SD || STORAGE_TYPE == STORAGE_FFAT
@@ -2102,14 +2072,13 @@ bool FtpServer::doMlsd()
 	#endif
 	#if defined(ESP8266) || defined(ARDUINO_ARCH_RP2040)
 		time_t time = dir.fileTime();
-		generateFileLine(&data, dir.isDirectory(), fn, fz, time, this->user);
+		buildListLine( false, dir.isDirectory(), fn, fz, time );
 	#elif defined(ESP32)
-		time_t time = fileDir.getLastWrite();
-		generateFileLine(&data, fileDir.isDirectory(), fn, fz, time, this->user);
+		buildListLine( false, fileDir.isDirectory(), fn, fz, fileDir.getLastWrite());
 	#else
-		generateFileLine(&data, fileDir.isDirectory(), fn, fz, "Jan 01 00:00", this->user);
+		buildListLine( false, fileDir.isDirectory(), fn, fz, "Jan 01 00:00" );
 	#endif
-    nbMatch ++;
+    sendListLine();
     return true;
   }
 #elif STORAGE_TYPE == STORAGE_SD || STORAGE_TYPE == STORAGE_SD_MMC
@@ -2132,21 +2101,8 @@ bool FtpServer::doMlsd()
 
 
 
-		data.print( F("Type=") );
-
-		data.print( ( fileDir.isDirectory() ? F("dir") : F("file")) );
-		data.print( F(";Modify=") ); data.print(dtStr);// data.print( makeDateTimeStr( dtStr, time, time) );
-		data.print( F(";Size=") ); data.print( fz );
-		data.print( F("; ") ); data.println( fn );
-
-		DEBUG_PRINT( F("Type=") );
-		DEBUG_PRINT( ( fileDir.isDirectory() ? F("dir") : F("file")) );
-
-		DEBUG_PRINT( F(";Modify=") ); DEBUG_PRINT(dtStr); //DEBUG_PRINT( makeDateTimeStr( dtStr, time, time) );
-		DEBUG_PRINT( F(";Size=") ); DEBUG_PRINT( fz );
-		DEBUG_PRINT( F("; ") ); DEBUG_PRINTLN( fn );
-
-		nbMatch ++;
+		buildMlsdLine( fileDir.isDirectory(), dtStr, fz, fn.c_str());
+		sendListLine();
 		return true;
 	  }
 
@@ -2154,11 +2110,10 @@ bool FtpServer::doMlsd()
   if( dir.nextFile())
   {
     char dtStr[ 15 ];
-    data.print( F("Type=") ); data.print( ( dir.isDir() ? F("dir") : F("file")) );
-    data.print( F(";Modify=") ); data.print( makeDateTimeStr( dtStr, dir.fileModDate(), dir.fileModTime()) );
-    data.print( F(";Size=") ); data.print( long( dir.fileSize()) );
-    data.print( F("; ") ); data.println( dir.fileName() );
-    nbMatch ++;
+    String fn = dir.fileName();
+    buildMlsdLine( dir.isDir(), makeDateTimeStr( dtStr, dir.fileModDate(), dir.fileModTime()),
+                   long( dir.fileSize()), fn.c_str());
+    sendListLine();
     return true;
   }
 #else
@@ -2171,18 +2126,11 @@ bool FtpServer::doMlsd()
     DEBUG_PRINTLN(gfmt);
     if( gfmt )
     {
-		  data.print( F("Type=") ); data.print( ( file.isDir() ? F("dir") : F("file")) );
-		  data.print( F(";Modify=") ); data.print( makeDateTimeStr( dtStr, filelwd, filelwt ) );
-		  data.print( F(";Size=") ); data.print( long( fileSize( file )) ); data.print( F("; ") );
-		  file.printName( & data );
-		  data.println();
-
-		  DEBUG_PRINT( F("Type=") ); DEBUG_PRINT( ( file.isDir() ? F("dir") : F("file")) );
-		  DEBUG_PRINT( F(";Modify=") ); DEBUG_PRINT( makeDateTimeStr( dtStr, filelwd, filelwt ) );
-		  DEBUG_PRINT( F(";Size=") ); DEBUG_PRINT( long( fileSize( file )) ); DEBUG_PRINT( F("; ") );
-//		  DEBUG_PRINT(file.name());
-		  DEBUG_PRINTLN();
-      nbMatch ++;
+		  char nameBuf[ FTP_CWD_SIZE ];
+		  file.getName( nameBuf, sizeof( nameBuf ));
+		  buildMlsdLine( file.isDir(), makeDateTimeStr( dtStr, filelwd, filelwt ),
+		                 long( fileSize( file )), nameBuf );
+		  sendListLine();
     }
     file.close();
     return gfmt;

--- a/FtpServer.cpp
+++ b/FtpServer.cpp
@@ -444,10 +444,23 @@ uint8_t FtpServer::handleFTP() {
 
 				transferStage = FTP_Close;
 			}
-		} else if (cmdStage > FTP_Client
+		}
+
+		// Out of the chain above, whose tail this was: a running transfer always took its own
+		// branch, so the deadline was never reached — and doRetrieve() now waits a stalled peer
+		// out instead of aborting, leaving nothing else to end it. RETR refreshes this deadline
+		// as it sends; the other types never do, so bounding them would kill them mid-progress.
+		const bool in_retrieve = (transferStage == FTP_Retrieve);
+		if (cmdStage > FTP_Client && (transferStage == FTP_Close || in_retrieve)
 				&& !((int32_t) (millisEndConnection - millis()) > 0)) {
-			DEBUG_PRINTLN(F("530 Timeout"));
-			client.println(F("530 Timeout"));
+			DEBUG_PRINTLN(F("Timeout"));
+			if (in_retrieve) {
+				// NOT closeTransfer(): that answers 226. abortTransfer() replies 426 and fires
+				// FTP_TRANSFER_ERROR, which releases what the app took.
+				abortTransfer();
+			} else {
+				client.println(F("530 Timeout"));
+			}
 			millisDelay = millis() + 200;       // delay of 200 ms
 			cmdStage = FTP_Stop;
 		}
@@ -1530,14 +1543,8 @@ bool FtpServer::doRetrieve()
     DEBUG_PRINT(F("WRITTEN --> "));
     DEBUG_PRINTLN(written);
 
-    if (written <= 0) {
-      DEBUG_PRINTLN(F("ERROR: data.write returned <= 0"));
-      abortTransfer();
-      return false;
-    }
-
     // If partial write, try to send the remainder (best-effort)
-    if (written < nb) {
+    if (written > 0 && written < nb) {
       int16_t remaining = nb - written;
       DEBUG_PRINT(F("Partial write, attempting remainder -> "));
       DEBUG_PRINTLN(remaining);
@@ -1581,7 +1588,14 @@ bool FtpServer::doRetrieve()
 
     bytesTransfered += written;
 
-	  if (FtpServer::_transferCallback) {
+    // Progress pushes the idle deadline out; a round that sent nothing deliberately does not —
+    // a zero write is often a transient shut window, and that deadline ends a peer really gone.
+    if (written > 0) {
+      millisEndConnection = millis() + 1000L * FTP_TIME_OUT;
+    }
+
+	  // Invoke callback on real progress: a stalled round must not look like a moving one to a watching app.
+	  if (written > 0 && FtpServer::_transferCallback) {
 		  FtpServer::_transferCallback(FTP_DOWNLOAD, getFileName(&file).c_str(), bytesTransfered);
 	  }
 

--- a/FtpServer.h
+++ b/FtpServer.h
@@ -502,6 +502,10 @@
 #define FTP_CWD_SIZE FF_MAX_LFN+8 // max size of a directory name
 #define FTP_FIL_SIZE FF_MAX_LFN   // max size of a file name
 #define FTP_CRED_SIZE 16          // max size of username and password
+// One rendered listing entry: the two names at the limits above, the widest a long prints,
+// the date makeDateTimeStrList() builds in its own char[25], the "Type=…;Size=…; " prefix,
+// CRLF and the terminator.
+#define FTP_LIST_LINE_SIZE (FTP_FIL_SIZE + FTP_CRED_SIZE + 64)
 #define FTP_NULLIP() IPAddress(0,0,0,0)
 
 enum ftpCmd { FTP_Stop = 0,       //  In this stage, stop any connection
@@ -585,6 +589,18 @@ private:
   bool    doStore();
   bool    doList();
   bool    doMlsd();
+  // Sends what is still pending of listLine. True once the whole entry is away — only then
+  // is it counted in nbMatch, and any byte accepted pushes the idle deadline out, so a
+  // listing rides out a shut window exactly as a retrieve does.
+  bool    sendListLine();
+  // The one path from this server to the data socket. Returns what the socket took, and a
+  // non-zero take is what pushes the idle deadline out — so no transfer path can send bytes
+  // without the deadline noticing, or move the deadline without sending any.
+  size_t  writeData(const uint8_t* p, size_t len);
+  void    buildListLine(bool isNlst, bool isDirectory, const char* fn, long fz, const char* time);
+  void    buildListLine(bool isNlst, bool isDirectory, const char* fn, long fz, time_t time);
+  void    buildMlsdLine(bool isDirectory, const char* dtStr, long fz, const char* fn);
+  uint16_t finishListLine(int rendered);
   void    closeTransfer();
   // Ends a transfer as FAILED: closes the file and the directory, replies exactly once —
   // `reply` replaces the default "426 Transfer aborted" — and fires FTP_TRANSFER_ERROR for the
@@ -833,6 +849,14 @@ private:
            dataPort;
   uint16_t iCL;                       // pointer to cmdLine next incoming char
   uint16_t nbMatch;
+
+  // One listing entry, rendered whole before any of it is sent. The directory cursor has
+  // already moved past the entry by then, so a line the peer only half accepts has to be
+  // resumed from here — re-reading it is impossible, and a half line left in the stream
+  // corrupts every entry after it.
+  char     listLine[ FTP_LIST_LINE_SIZE ];
+  uint16_t listLineLen = 0;                 // rendered length; 0 = no entry pending
+  uint16_t listLineSent = 0;                // how much of it the socket has taken
 
   uint32_t millisDelay,               //
            millisEndConnection,       //

--- a/FtpServer.h
+++ b/FtpServer.h
@@ -586,7 +586,10 @@ private:
   bool    doList();
   bool    doMlsd();
   void    closeTransfer();
-  void    abortTransfer();
+  // Ends a transfer as FAILED: closes the file and the directory, replies exactly once —
+  // `reply` replaces the default "426 Transfer aborted" — and fires FTP_TRANSFER_ERROR for the
+  // stages that carry a file, so a listing that loses its data connection reports no transfer.
+  void    abortTransfer(const __FlashStringHelper* reply = nullptr);
   bool    makePath( char * fullName, char * param = nullptr );
   bool    makeExistsPath( char * path, char * param = nullptr );
   bool    openDir( FTP_DIR * pdir );


### PR DESCRIPTION
> **Stacked on #98.** This branch sits on top of the transfer-robustness fixes in #98, so
> until that one is merged the commit list here shows both. Review this pull request for the
> command hook alone; merging #98 first leaves this one with a single commit.

# Command hook extension

## Problem

Applications currently have no way to influence how the server handles individual FTP commands.

The existing `setCallback` and `setTransferCallback` APIs are invoked only after a command has already been processed and return `void`. They are useful for observing server activity, but they cannot modify, reject, or replace command handling.

As a result, several common extension scenarios are currently impossible or require patching the server implementation:

* **Reject a command** — refuse selected verbs, for example to run a read-only server.
* **Rewrite a command** — alias one command to another while reusing the built-in handler.
* **Implement a command** — handle a custom or extension verb directly, for example returning the server time.
* **Add a custom transfer** — stream generated data that no standard FTP command can produce, such as a multi-file bundle or on-the-fly compression.
* **Control session authorization** — implement custom authentication and authorization logic, such as validating tokens, one-time codes, or external identity providers, and revoke access to active sessions when required.

## Proposal

This PR introduces an optional command hook that gives applications control over the handling of individual FTP commands.

The hook is fully backward-compatible. If no hook is registered, the server behaves exactly as it does today.

## API

```cpp
class FtpResponse {
public:
  void reply(const char* line);                             // send one response line ("550 …"); marks the command done
  void rewriteCommand(const char* cmd, const char* param);  // run a different command instead of this one
  bool isAuthenticated() const;                             // has the client passed USER/PASS?
  void setAuthenticated(bool);                              // let the hook do its own auth (token, IP allow-list, …)
  bool beginCustomTransfer(const CustomTransfer* xfer, void* ctx);
};

// The struct a custom transfer is defined by (passed to beginCustomTransfer):
struct CustomTransfer {
  enum TransferResult { TR_DONE, TR_ABORTED };         // how the transfer ended, passed to onEnd
  const char* name;                                    // label for setTransferCallback (there is no `file`)
  int  (*sendChunk)(void* ctx, Client& data);           // >0 = bytes sent, 0 = nothing yet, -1 = done, <-1 = error
  const char* (*onEnd)(void* ctx, TransferResult r);   // custom final reply line, or nullptr for default (226/426)
};

void setCommandHandler(void (*fn)(FtpResponse& res, const char* command, const char* parameter));
```

The hook runs for every command, immediately before the server's built-in handler. It does not return a value. Instead, its interaction with `FtpResponse` determines what happens next:

| Hook action                           | Server behavior                                                 |
| ------------------------------------- | --------------------------------------------------------------- |
| `res.reply("550 …")`                  | The reply is sent and the built-in handler does not run.        |
| `res.rewriteCommand(cmd, param)`      | The rewritten command runs instead of the original command.     |
| `res.beginCustomTransfer(&xfer, ctx)` | The custom transfer runs and the built-in handler does not run. |
| No action                             | The original command runs normally.                             |

Because handling is expressed through `FtpResponse`, there is no return value to interpret incorrectly. Calling `reply()` marks the command as handled, so the hook cannot both send a reply and allow the built-in handler to send another one.

`FtpResponse` intentionally exposes only these operations. Internal server methods such as `begin()`, `end()`, `handleFTP()`, and callback registration are not reachable from the hook.

## Custom transfers

`beginCustomTransfer()` allows a hook to stream data that no standard FTP command can produce, such as generated reports, multi-file bundles, or on-the-fly compression.

Transfers are driven incrementally from `handleFTP()`, one chunk per call, so the control connection remains responsive and never blocks waiting for the producer.

`onEnd()` is guaranteed to run exactly once regardless of how the transfer finishes:

* normal completion
* `ABOR`
* client disconnect
* dropped connection
* server shutdown through `end()`

This provides a single place to close files, release buffers, and perform cleanup.

Transfer byte counts continue flowing through the existing `setTransferCallback`, so progress reporting and stall watchdogs continue to work for custom transfers.

## Safety

* `rewriteCommand` copies into the server's fixed `command[]` and `cmdLine[]` buffers using bounded operations (`strncpy`/`strnlen`). It also handles cases where `param` points into the same buffer using `memmove`.
* Rewritten commands are **not** passed through the hook again. When rewriting a command, apply policy to the rewritten command as well as the original command.

## Examples

### Read-only server

Reject write operations while allowing all normal read commands to continue through the built-in handler:

```cpp
void onCommand(FtpResponse& res, const char* command, const char*) {
  static const char* WRITE[] = {
    "STOR","APPE","STOU","DELE","MKD","RMD","RNFR","RNTO","MFMT"
  };

  for (auto w : WRITE)
    if (strcmp(command, w) == 0) {
      res.reply("550 Read-only server.");
      return;
    }

  // Read commands fall through and run normally.
}

ftp.setCommandHandler(&onCommand);
```

### Command aliasing

Rewrite a command while continuing to use the built-in handler.

For example, `RETR LATEST` can be translated into a request for the newest file while preserving existing RETR behavior such as resume support and access checks:

```cpp
void onCommand(FtpResponse& res, const char* command, const char* parameter) {
  if (strcmp(command, "RETR") == 0 &&
      parameter &&
      strcasecmp(parameter, "LATEST") == 0) {

    res.rewriteCommand("RETR", newestFile());

    // No reply: the server runs "RETR <newest>"
  }
}

ftp.setCommandHandler(&onCommand);
```

### Custom authentication

The hook runs before the built-in authentication flow, allowing applications to provide their own authentication mechanism.

For example, the library can still handle `USER`, while the hook handles `PASS` using a token, hash, rotating one-time code, or external identity service:

```cpp
void onCommand(FtpResponse& res, const char* command, const char* parameter) {
  if (strcmp(command, "PASS") == 0) {
    if (parameter && checkToken(parameter)) {
      res.setAuthenticated(true);
      res.reply("230 Login successful.");
    } else {
      res.setAuthenticated(false);
      res.reply("530 Authentication failed.");
    }

    return;
  }
}

ftp.setCommandHandler(&onCommand);
```

`setAuthenticated(true)` marks the session as authenticated, allowing subsequent commands to pass the built-in authentication check. `isAuthenticated()` can be used by hooks that need to inspect the current session state.

### Implement a command

Handle a custom or extension command directly without involving a data connection:

```cpp
void onCommand(FtpResponse& res, const char* command, const char*) {
  if (strcmp(command, "TIME") == 0) {
    char line[40];

    snprintf(line, sizeof(line),
             "211 %lu",
             (unsigned long)time(nullptr));

    res.reply(line);
  }
}

ftp.setCommandHandler(&onCommand);
```

### Custom generated transfer

Serve generated data that does not exist as a file on disk:

```cpp
struct TransferContext {
  const char* p;
  size_t left;
};

static TransferContext g_ctx;

int sendChunk(void* ctx, Client& data) {
  TransferContext* c = (TransferContext*)ctx;

  if (c->left == 0)
    return -1; // done

  size_t n = data.write((const uint8_t*)c->p, c->left);

  c->p += n;
  c->left -= n;

  return (int)n; // >0 sent, 0 retry later
}

const char* onEnd(void*, TransferResult r) {
  // Cleanup runs exactly once.
  return (r == TR_DONE) ? "226 Report sent." : nullptr;
}

static const CustomTransfer REPORT = {
  "report.txt",
  &sendChunk,
  &onEnd
};

void onCommand(FtpResponse& res, const char* command, const char* parameter) {
  if (strcmp(command, "RETR") == 0 &&
      parameter &&
      strcmp(parameter, "report.txt") == 0) {

    static const char TEXT[] =
      "generated on the fly, no file on disk\n";

    g_ctx = { TEXT, sizeof(TEXT) - 1 };

    res.beginCustomTransfer(&REPORT, &g_ctx);
  }
}

ftp.setCommandHandler(&onCommand);
```

## Compatibility

This change is purely additive.

No existing function signatures change, and when no command hook is installed the server behavior is unchanged.
